### PR TITLE
Refactor to separate concerns

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -63,8 +63,8 @@
       # This also is where the benefits of using a "glob" come into play...
       # See: https://github.com/mapbox/node-cpp-skel/pull/44#discussion_r122050205
       'sources': [ 
-        './src/module.cpp',
-        './src/vtvalidate.cpp'
+        './src/nan-init.cpp',
+        './src/vtvalidate-nan.cpp'
       ],
       'ldflags': [
         '-Wl,-z,now',

--- a/src/nan-init.cpp
+++ b/src/nan-init.cpp
@@ -1,4 +1,4 @@
-#include "vtvalidate.hpp"
+#include "vtvalidate-nan.hpp"
 #include <nan.h>
 
 // "target" is a magic var that nodejs passes into a module's scope.
@@ -7,7 +7,7 @@
 static void init(v8::Local<v8::Object> target) {
 
     // expose isValid method
-    Nan::SetMethod(target, "isValid", VectorTileValidate::isValid);
+    Nan::SetMethod(target, "isValid", vtvalidate_nan::isValid);
 }
 
 // Here we initialize the module (we only do this once)

--- a/src/vtvalidate-core.hpp
+++ b/src/vtvalidate-core.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <exception>
+#include <iostream>
+#include <map>
+#include <stdexcept>
+#include <vtzero/vector_tile.hpp>
+
+namespace vtvalidate_core {
+
+namespace detail {
+
+struct geom_handler {
+    void points_begin(uint32_t /*dummy*/) {}
+    void points_point(const vtzero::point /*dummy*/) {}
+    void points_end() const noexcept {}
+    void linestring_begin(uint32_t /*dummy*/) {}
+    void linestring_point(const vtzero::point /*dummy*/) {}
+    void linestring_end() const noexcept {}
+    void ring_begin(uint32_t /*dummy*/) {}
+    void ring_point(const vtzero::point /*dummy*/) {}
+    void ring_end(vtzero::ring_type /*dummy*/) const noexcept {}
+};
+
+}
+
+std::string parseTile(vtzero::data_view const& buffer) {
+    std::string result;
+
+    vtzero::vector_tile tile{buffer};
+    try {
+        while (auto layer = tile.next_layer()) {
+            while (auto feature = layer.next_feature()) {
+                // Detect geomtype of feature and decode
+                detail::geom_handler handler;
+                vtzero::decode_geometry(feature.geometry(), handler);
+
+                feature.for_each_property([&](vtzero::property const& p) {
+                    p.key();
+                    auto value = p.value();
+                    switch (value.type()) {
+                    case vtzero::property_value_type::string_value:
+                        value.string_value();
+                        break;
+                    case vtzero::property_value_type::float_value:
+                        value.float_value();
+                        break;
+                    case vtzero::property_value_type::double_value:
+                        value.double_value();
+                        break;
+                    case vtzero::property_value_type::int_value:
+                        value.int_value();
+                        break;
+                    case vtzero::property_value_type::uint_value:
+                        value.uint_value();
+                        break;
+                    case vtzero::property_value_type::sint_value:
+                        value.sint_value();
+                        break;
+                    case vtzero::property_value_type::bool_value:
+                        value.bool_value();
+                        break;
+                    // LCOV_EXCL_START
+                    default:
+                        throw std::runtime_error("Invalid property value type"); // this can never happen, since vtzero handles the error earlier
+                        // LCOV_EXCL_STOP
+                    }
+                    return true; // continue to next property
+
+                });
+            }
+        }
+    } catch (std::exception const& ex) {
+        result = ex.what();
+        return result;
+    }
+
+    result = "";
+    return result;
+}
+
+} // namespace vtvalidate_core

--- a/src/vtvalidate-nan.hpp
+++ b/src/vtvalidate-nan.hpp
@@ -1,0 +1,6 @@
+#pragma once
+#include <nan.h>
+
+namespace vtvalidate_nan {
+NAN_METHOD(isValid);
+}


### PR DESCRIPTION
There are two basic concerns in `vtvalidate`:

 - Validation of vector tiles with vtzero
 - Binding the validation code to be able to call from node.js with nan helpers

This PR separates the code these two ways, and renames things accordingly. This sets us up to be able to, with minimal changes/friction, consider these things:

 - Be able to write WebAssembly bindings to the core code
 - Be able to easily/eventually extract the pure C++ code (no node dep) into https://github.com/mapbox/vector-tile
 - Be able to write pure C++ unit tests against `vt_validate::parseTile` - this might be useful if we want to pass in invalid input that could happen via node but would be difficult to trigger in normal circumstances/in units tests. Like: what happens if we pass in bogus data or a `nullptr`?

 