### PR TITLE
Switch to using gzip-hpp for compression in vtvalidate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ mason_packages
 .mason
 .toolchain
 local.env
+npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+/node_modules
+/test

--- a/bin/vtvalidate.js
+++ b/bin/vtvalidate.js
@@ -4,7 +4,6 @@
 
 var exists = require('fs').existsSync;
 var fs = require('fs');
-var zlib = require('zlib');
 
 var usage = 'usage:';
 usage += '\n  node bin/vtvalidate.js <vector tile>';
@@ -22,51 +21,12 @@ if (!exists(input_tile)) {
 
 var validator = require('../');
 var buffer = fs.readFileSync(input_tile);
-var wasCompressedBuffer = decompressBuffer(buffer);
 
-// Allow compressed gzip or compressed zlib
-function decompressBuffer(buffer) {
-    if (buffer[0] === 0x1F && buffer[1] === 0x8B) {
-        try {
-            var result = zlib.gunzipSync(buffer);
-            return result;
-        } catch(err) {
-            console.error(err.message);
-            process.exit(1);
-        }
-    } 
-    else if (buffer[0] === 0x78 && 
-        (buffer[1] === 0x9C ||
-         buffer[1] === 0x01 ||
-         buffer[1] === 0xDA ||
-         buffer[1] === 0x5E)) {
-      
-      try {
-        var result = zlib.inflateSync(buffer);
-        return result;
-      } catch(err) {
+validator.isValid(wasCompressedBuffer, function(err, valid) {
+    if (err) {
         console.error(err.message);
         process.exit(1);
-      }
-    } else return null;
-}
-
-if (wasCompressedBuffer) {
-    validator.isValid(wasCompressedBuffer, function(err, valid) {
-        if (err) {
-            console.error(err.message);
-            process.exit(1);
-        }
-        process.stdout.write(valid); // Using "if (valid)" here because vtvalidate returns "/n" for some reason
-        process.exit(0);
-    });    
-} else {
-    validator.isValid(buffer, function(err, valid) {
-        if (err) {
-            console.error(err.message);
-            process.exit(1);
-        }
-        process.stdout.write(valid); // Using "if (valid)" here because vtvalidate returns "/n" for some reason
-        process.exit(0);
-    });    
-}
+    }
+    process.stdout.write(valid); // Using "if (valid)" here because vtvalidate returns "/n" for some reason
+    process.exit(0);
+});

--- a/bin/vtvalidate.js
+++ b/bin/vtvalidate.js
@@ -22,7 +22,7 @@ if (!exists(input_tile)) {
 var validator = require('../');
 var buffer = fs.readFileSync(input_tile);
 
-validator.isValid(wasCompressedBuffer, function(err, valid) {
+validator.isValid(buffer, function(err, valid) {
     if (err) {
         console.error(err.message);
         process.exit(1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtvalidate",
-  "version": "0.1.0-alpha1",
+  "version": "0.1.0-dev-gziphpp",
   "description": "Simply checks if a vector tile contains valid/invalid geometries",
   "url": "http://github.com/mapbox/vtvalidate",
   "main": "./lib/index.js",

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -14,3 +14,4 @@ source local.env
 
 install protozero 1.6.1
 install vtzero f6efb8e
+install gzip-hpp 0.1.0

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -13,5 +13,5 @@ function install() {
 source local.env
 
 install protozero 1.6.1
-install vtzero f6efb8e
+install vtzero 1.0.0
 install gzip-hpp 0.1.0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,8 +3,8 @@
 set -eu
 set -o pipefail
 
-export MASON_RELEASE="${MASON_RELEASE:-141cb63}"
-export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.0}"
+export MASON_RELEASE="${MASON_RELEASE:-1785c00}"
+export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-6.0.0}"
 
 PLATFORM=$(uname | tr A-Z a-z)
 if [[ ${PLATFORM} == 'darwin' ]]; then

--- a/src/vtvalidate.cpp
+++ b/src/vtvalidate.cpp
@@ -120,9 +120,11 @@ struct AsyncValidateWorker : Nan::AsyncWorker {
                 gzip::Decompressor decompressor;
                 std::string uncompressed;
                 decompressor.decompress(uncompressed, data.data(), data.size());
-                data = vtzero::data_view(uncompressed);
+                vtzero::data_view dv(uncompressed);
+                result_ = parseTile(dv);
+            } else {
+                result_ = parseTile(data);
             }
-            result_ = parseTile(data);
         } catch (const std::exception& e) {
             SetErrorMessage(e.what());
         }

--- a/src/vtvalidate.cpp
+++ b/src/vtvalidate.cpp
@@ -185,12 +185,6 @@ NAN_METHOD(isValid) {
         return;
     }
 
-    // set up the baton to pass into our threadpool
-    auto* baton = new AsyncBaton();
-    baton->request.data = baton;
-    baton->data = node::Buffer::Data(buffer);
-    baton->dataLength = node::Buffer::Length(buffer);
-
     // Creates a worker instance and queues it to run asynchronously, invoking the
     // callback when done.
     // - Nan::AsyncWorker takes a pointer to a Nan::Callback and deletes the

--- a/src/vtvalidate.cpp
+++ b/src/vtvalidate.cpp
@@ -76,7 +76,6 @@ std::string parseTile(vtzero::data_view const& buffer) {
                         // LCOV_EXCL_STOP
                     }
                     return true; // continue to next property
-
                 });
             }
         }
@@ -150,7 +149,7 @@ struct AsyncValidateWorker : Nan::AsyncWorker {
 
     // explicitly use the destructor to clean up
     // the persistent tile ref by Reset()-ing
-    ~AsyncValidateWorker() {
+    ~AsyncValidateWorker() override {
         keep_alive_.Reset();
     }
 };

--- a/test/isValid.test.js
+++ b/test/isValid.test.js
@@ -1,6 +1,9 @@
 var test = require('tape');
+var fs = require('fs');
+var path = require('path');
 var module = require('../lib/index.js');
 var mvtf = require('@mapbox/mvt-fixtures');
+var mvtfixtures = path.resolve(__dirname, '..', 'node_modules', '@mapbox', 'mvt-fixtures');
 
 test('success: valid tile', function(t) {
   var buffer = mvtf.get('043').buffer;
@@ -31,6 +34,24 @@ test('success: valid linestring', function(t) {
 
 test('success: valid ring', function(t) {
   var buffer = mvtf.get('022').buffer;
+  module.isValid(buffer, function(err, result) {
+    if (err) throw err;
+    t.equal(result, '');
+    t.end();
+  });
+});
+
+test('success: valid zlib compressed', function(t) {
+  var buffer = fs.readFileSync(__dirname + '/fixtures/zlib-compressed');
+  module.isValid(buffer, function(err, result) {
+    if (err) throw err;
+    t.equal(result, '');
+    t.end();
+  });
+});
+
+test('success: valid gzip compressed', function(t) {
+  var buffer = fs.readFileSync(mvtfixtures + '/real-world/compressed/14-9384-9577.mvt.gz');
   module.isValid(buffer, function(err, result) {
     if (err) throw err;
     t.equal(result, '');


### PR DESCRIPTION
## Description
Use gzip-hpp to decompress tile buffers for validation.

Per mapbox/core-tech#342 and https://github.com/mapbox/core-tech/issues/245
Referencing https://github.com/mapbox/vt-shaver-cpp/pull/152

## Changes
#### bin/vtvalidate.js 
* Removed `decompressBuffer` and now doing decompression in `src/vtvalidate.cpp`
#### scripts/install_deps.sh
* Updated vtzero dependency to 1.0.0
* Added gzip-hpp 0.1.0 dependency
#### scripts/setup.sh
* Updated mason to 1785c00
* Updated llvm to 6.0.0
#### src/vtvalidate.cpp
* Added decompression code using `gzip::Decompressor` to `AsyncValidateWorker`