### PR TITLE
Fix benchmark to handle errors for invalid tiles

### DIFF
--- a/bench/isValid.bench.js
+++ b/bench/isValid.bench.js
@@ -53,15 +53,18 @@ var start = function(files){
     module.isValid(buffer, function(err, result) {
         if (err) {
           return cb(err);
+        } else if (result.length > 0) {
+          return cb(new Error(result));
+        } else {
+          ++runs;
+          if (track_mem && runs % 1000) {
+            var mem = process.memoryUsage();
+            if (mem.rss > memstats.max_rss) memstats.max_rss = mem.rss;
+            if (mem.heapTotal > memstats.max_heap_total) memstats.max_heap_total = mem.heapTotal;
+            if (mem.heapUsed > memstats.max_heap) memstats.max_heap = mem.heapUsed;
+          }
+          return cb();
         }
-        ++runs;
-        if (track_mem && runs % 1000) {
-          var mem = process.memoryUsage();
-          if (mem.rss > memstats.max_rss) memstats.max_rss = mem.rss;
-          if (mem.heapTotal > memstats.max_heap_total) memstats.max_heap_total = mem.heapTotal;
-          if (mem.heapUsed > memstats.max_heap) memstats.max_heap = mem.heapUsed;
-        }
-        return cb();
     });
   }
 


### PR DESCRIPTION
My expectation is that the benchmark script will throw errors and abort (without posting performance results) if passed invalid data that it can't handle. 

This fixes a glitch in the benchmark to actually throw on validation errors, which are unexpected in the benchmark. Currently we're only benchmarking against valid tiles not how fast we throw on invalid tiles.

Refs https://github.com/mapbox/vtvalidate/pull/18#issuecomment-398245298

/cc @allieoop @GretaCB 