### PR TITLE
Remove .npmignore due to ELF Header

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-/node_modules
-/test


### PR DESCRIPTION
Per https://travis-ci.org/mapbox/mapbox-tile-copy/jobs/394271159#L2123 and similar to https://github.com/mapbox/node-cpp-skel/issues/98, removing `.npmignore` to avoid this happening in the future.

cc @allieoop @springmeyer 